### PR TITLE
Fix get_next_line invalid write/read bug

### DIFF
--- a/get_next_line/get_next_line.c
+++ b/get_next_line/get_next_line.c
@@ -6,7 +6,7 @@
 /*   By: ribana-b <ribana-b@student.42malaga.com>   +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/22 15:46:17 by ribana-b          #+#    #+# Malaga      */
-/*   Updated: 2024/06/02 11:04:36 by ribana-b         ###   ########.com      */
+/*   Updated: 2024/06/15 17:37:20 by ribana-b         ###   ########.com      */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,7 +70,7 @@ static char	*read_temp(char *temp)
 	index = 0;
 	while (temp[index] != '\n' && temp[index] != '\0')
 		index++;
-	line = (char *)malloc((index + temp[index] == '\n' + 1) * sizeof(char));
+	line = (char *)malloc((index + (temp[index] == '\n') + 1) * sizeof(char));
 	if (!line)
 		return (NULL);
 	index = 0;


### PR DESCRIPTION
The refactor in this commit 03c3ad16f549fc11e2fc144a00afbde3e27122e9 broke the amount of bytes given by malloc because of missing parentheses.

It was doing `(index + temp[index]) == ('\n' + 1)`, instead of `index + (temp[index] == '\n') + 1`, which is the desired behaviour.

This fixes issue #31